### PR TITLE
fix: coerce_value must check NodeTree before returning for None target

### DIFF
--- a/src/blender_mcp_addon/handlers/utils/property_parser.py
+++ b/src/blender_mcp_addon/handlers/utils/property_parser.py
@@ -36,14 +36,15 @@ def coerce_value(value: Any, target: Any = None) -> Any:
         if not isinstance(value, str):
             return value
 
+    # Handle NodeTree references - check BEFORE returning for None target
+    # because node.node_tree can be None on new Group nodes
+    if _is_node_tree_target(target):
+        return _to_node_tree(value, target)
+
     if target is None:
         return value
 
     target_type = type(target).__name__
-
-    # Handle NodeTree references - allow setting node_tree property by name
-    if _is_node_tree_target(target):
-        return _to_node_tree(value, target)
 
     if target_type == "Color" or _is_color_target(target):
         return _to_color(value)


### PR DESCRIPTION
## Summary

Fixes a bug discovered during testing of #168.

## Problem

When setting `node_tree` property on a new Group node, `set_property` operation failed with:
```
"bpy_struct: item.attr = val: ShaderNodeGroup.node_tree expected a NodeTree type, not str"
```

## Root Cause

In `coerce_value()`, the check `if target is None: return value` happened **before** the NodeTree reference check. Since new Group nodes have `node_tree = None`, the string value was returned without being resolved to a NodeTree object.

## Fix

Move the `_is_node_tree_target(target)` check **before** the `if target is None` return, so string-to-NodeTree conversion happens even when the current property value is None.

## Test Plan

1. Create a ShaderNodeTree via `blender_edit_nodes` with `NODE_GROUP` context
2. Create a material and add a `ShaderNodeGroup` node
3. Set `node_tree` property via `set_property` with string name
4. Verify Group node has correct input/output sockets