### PR TITLE
fix: update node_index after add_node and remove_node

### DIFF
--- a/src/blender_mcp_addon/handlers/nodes/editor.py
+++ b/src/blender_mcp_addon/handlers/nodes/editor.py
@@ -412,13 +412,19 @@ def node_tree_edit(payload: dict[str, Any], *, started: float) -> dict[str, Any]
                     node.label = op["name"]
                 if op.get("location"):
                     node.location = tuple(op["location"])
+                node_index[node.name] = node
+                node_index[node.bl_idname] = node
                 results.append({"op": i, "action": "add_node", "name": node.name, "ok": True})
 
             elif action == "remove_node":
                 node_name = op.get("name", "")
                 node = _get_node(node_tree, node_name, node_index)
                 if node:
+                    actual_name = node.name
+                    bl_idname = node.bl_idname
                     node_tree.nodes.remove(node)
+                    node_index.pop(actual_name, None)
+                    node_index.pop(bl_idname, None)
                     results.append(
                         {
                             "op": i,


### PR DESCRIPTION
## Summary

Fixes a bug where operations after `add_node` in the same request couldn't find the newly added node.

## Problem

`node_index` was built once at the start of `node_tree_edit()`, but never updated when nodes were added or removed. This caused:

```json
// This would fail:
{
  "operations": [
    {"action": "add_node", "type": "ShaderNodeGroup", "name": "Group"},
    {"action": "set_property", "node": "Group", "property": "node_tree", "value": "MyGroup"}
  ]
}
// Result: set_property fails with "node or property not found"
```

## Fix

- `add_node` now updates `node_index` with the new node's name and bl_idname
- `remove_node` now removes the deleted node from `node_index`

## Test Plan

- [x] All unit tests pass (511 tests)
- [ ] Manual testing in Blender